### PR TITLE
AndroidNumberPicker mistake prop name is fixed.

### DIFF
--- a/picker-view/index.js
+++ b/picker-view/index.js
@@ -39,7 +39,7 @@ export default class NumberPicker extends Component {
             <AndroidNumberPicker
                 values={values}
                 style={[style]}
-                selected={selected}
+                selectedIndex={selected}
                 height={height}
                 enableInput={enableInput}
                 onSelect={(index)=>{


### PR DESCRIPTION
There was an issue in the AndroidNumberPicker prop assignment, and if fixed it. Please accept the pull request.